### PR TITLE
Add setup.py and upd gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,31 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
-*.pyc
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+*.vscode
+MANIFEST
+*.idea
+*.vscode
+.flake8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## AutoDoubleML
 
+See a demo example at [example.ipynb](example.ipynb)
+
 #### Clone Git Repo
 
 ```{bash}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
-# AutoDoubleML
+## AutoDoubleML
 
-This is currently a playground to evaluate possibilities of automating the DoubleML learner selection and tuning.
+#### Clone Git Repo
 
-See 'example.ipynb' for an example.
+```{bash}
+git clone https://github.com/OliverSchacht/AutoDoubleML
+```
+
+#### Install requirements
+
+```{bash}
+pip install requirements.txt
+```
+
+#### Pip install local package
+
+```{bash}
+pip install .
+```
+
+#### Use package 
+
+```{python}
+import autodml
+```
+or import a single class only
+
+```{python}
+from autodml.AutoDoubleMLPLR import AutoDoubleMLPLR
+```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+from pathlib import Path
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
+setup(
+    name='AutoDoubleML',
+    version='0.0.9000',
+    description='Additional DoubleML classes to integrate AutoML frameworks in DoubleML (work in progress).',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author='Oliver Schacht, Philipp Bach',
+    author_email='oliver.schacht@uni-hamburg.de',
+    packages=find_packages(),
+    install_requires=[
+        'DoubleML',
+        'numpy',
+        'pandas',
+    ],
+    include_package_data=True,
+    python_requires='>=3.9',
+)


### PR DESCRIPTION
The package `AutoDoubleML` can now be installed with

#### Clone Git Repo

```{bash}
git clone https://github.com/OliverSchacht/AutoDoubleML
```

#### Install requirements

```{bash}
pip install requirements.txt
```

#### Pip install local package

```{bash}
pip install .
```

#### Use package 

```{python}
import autodml
```
or import a single class only

```{python}
from autodml.AutoDoubleMLPLR import AutoDoubleMLPLR
```